### PR TITLE
Capture background window screenshots using native PrintWindow API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Improved
+- `windows_screenshot` now captures background (occluded) windows using the native `PrintWindow` API with `PW_RENDERFULLCONTENT`, falling back to standard capture when unavailable. No admin rights required.
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/src/FlaUI.Mcp/Core/NativeWindowCapture.cs
+++ b/src/FlaUI.Mcp/Core/NativeWindowCapture.cs
@@ -1,0 +1,98 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using FlaUI.Core.AutomationElements;
+
+namespace PlaywrightWindows.Mcp.Core;
+
+/// <summary>
+/// Captures window content using the native Win32 PrintWindow API,
+/// which can render windows even when they are occluded by other windows.
+/// </summary>
+internal static class NativeWindowCapture
+{
+    private const uint PW_RENDERFULLCONTENT = 0x00000002;
+
+    /// <summary>
+    /// Attempts to capture a window's content using the native PrintWindow API.
+    /// This works even when the window is behind other windows.
+    /// </summary>
+    /// <param name="window">The window to capture.</param>
+    /// <param name="imageData">The captured image as a PNG byte array, or empty on failure.</param>
+    /// <param name="failureReason">A description of why capture failed, or null on success.</param>
+    /// <returns>True if the window was captured successfully; false otherwise.</returns>
+    public static bool TryCaptureWindow(Window window, out byte[] imageData, out string? failureReason)
+    {
+        imageData = Array.Empty<byte>();
+        failureReason = null;
+
+        if (!window.Properties.NativeWindowHandle.TryGetValue(out var nativeWindowHandle) || nativeWindowHandle == 0)
+        {
+            failureReason = "No native window handle available";
+            return false;
+        }
+
+        var hwnd = new IntPtr(nativeWindowHandle);
+
+        if (!GetWindowRect(hwnd, out var rect))
+        {
+            failureReason = "Could not read window bounds";
+            return false;
+        }
+
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+
+        if (width <= 0 || height <= 0)
+        {
+            failureReason = "Window has invalid bounds";
+            return false;
+        }
+
+        try
+        {
+            using var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            using var graphics = Graphics.FromImage(bitmap);
+            var hdc = graphics.GetHdc();
+
+            try
+            {
+                var rendered = PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT);
+                if (!rendered)
+                {
+                    failureReason = "PrintWindow failed";
+                    return false;
+                }
+            }
+            finally
+            {
+                graphics.ReleaseHdc(hdc);
+            }
+
+            using var stream = new MemoryStream();
+            bitmap.Save(stream, ImageFormat.Png);
+            imageData = stream.ToArray();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            failureReason = ex.Message;
+            return false;
+        }
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+}

--- a/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
@@ -1,28 +1,40 @@
 using System.Text.Json;
+using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Capturing;
 using PlaywrightWindows.Mcp.Core;
 
 namespace PlaywrightWindows.Mcp.Tools;
 
 /// <summary>
-/// Take a screenshot
+/// MCP tool that captures screenshots of windows, elements, or the full screen.
+/// Window-level captures use native PrintWindow for background-friendly capture,
+/// falling back to standard FlaUI capture when unavailable.
 /// </summary>
 public class ScreenshotTool : ToolBase
 {
     private readonly SessionManager _sessionManager;
     private readonly ElementRegistry _elementRegistry;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScreenshotTool"/> class.
+    /// </summary>
+    /// <param name="sessionManager">The session manager for window lookups.</param>
+    /// <param name="elementRegistry">The element registry for ref-based element lookups.</param>
     public ScreenshotTool(SessionManager sessionManager, ElementRegistry elementRegistry)
     {
         _sessionManager = sessionManager;
         _elementRegistry = elementRegistry;
     }
 
+    /// <inheritdoc />
     public override string Name => "windows_screenshot";
 
+    /// <inheritdoc />
     public override string Description => 
-        "Take a screenshot of a window or specific element. Returns the image as base64-encoded PNG.";
+        "Take a screenshot of a window or specific element. Returns the image as base64-encoded PNG. " +
+        "Window captures attempt a background-friendly native capture first, then fall back to standard capture.";
 
+    /// <inheritdoc />
     public override object InputSchema => new
     {
         type = "object",
@@ -46,6 +58,7 @@ public class ScreenshotTool : ToolBase
         }
     };
 
+    /// <inheritdoc />
     public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
     {
         var handle = GetStringArgument(arguments, "handle");
@@ -76,6 +89,12 @@ public class ScreenshotTool : ToolBase
                 {
                     return Task.FromResult(ErrorResult($"Window not found: {handle}"));
                 }
+
+                if (NativeWindowCapture.TryCaptureWindow(window, out var backgroundImage, out _))
+                {
+                    return Task.FromResult(ImageResult(backgroundImage, "image/png"));
+                }
+
                 capture = Capture.Element(window);
             }
             else
@@ -97,6 +116,12 @@ public class ScreenshotTool : ToolBase
                 if (current == null)
                 {
                     return Task.FromResult(ErrorResult("Could not find window for focused element"));
+                }
+
+                var currentWindow = current.AsWindow();
+                if (currentWindow != null && NativeWindowCapture.TryCaptureWindow(currentWindow, out var backgroundImage, out _))
+                {
+                    return Task.FromResult(ImageResult(backgroundImage, "image/png"));
                 }
 
                 capture = Capture.Element(current);


### PR DESCRIPTION
## Summary
windows_screenshot can now capture windows that are behind other windows (occluded) without requiring them to be brought to the foreground. No admin rights required.

## Changes
- Added `NativeWindowCapture` helper that uses Win32 `PrintWindow` with `PW_RENDERFULLCONTENT` to render window contents even when occluded by other windows
- Updated `ScreenshotTool` to attempt native capture first for window-level screenshots (by handle or focused window), falling back to existing FlaUI `Capture.Element` if native capture fails
- Element-level (`ref`) and full-screen captures are unchanged
- Added XML doc comments for all public/protected members
- Updated CHANGELOG.md

## How it works
`PrintWindow` asks the target window to paint itself into a provided device context, so it renders its own content regardless of Z-order. The `PW_RENDERFULLCONTENT` flag enables full DWM composition rendering. This works without elevation on Windows 10/11 for standard Win32, WPF, WinForms, and most UWP apps.

## Testing
Manually verified with Spotify running behind other windows - before this change, the screenshot showed other windows bleeding through; after, the full Spotify UI is captured cleanly in the background.