### PR TITLE
fix: enable DPI awareness for correct screenshot capture on scaled displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Screenshots are now correct on scaled displays (DPI > 100%). Added `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` as the first call in the process entry point so UIA coordinates match physical pixels.
+
+### Added
+- Solution file (`FlaUI.Mcp.slnx`)
+- xUnit test project (`tests/FlaUI.Mcp.Tests`) with DPI regression test
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/FlaUI.Mcp.slnx
+++ b/FlaUI.Mcp.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/FlaUI.Mcp/FlaUI.Mcp.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/FlaUI.Mcp.Tests/FlaUI.Mcp.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/src/FlaUI.Mcp/Core/DpiUtility.cs
+++ b/src/FlaUI.Mcp/Core/DpiUtility.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace PlaywrightWindows.Mcp.Core;
+
+internal static class DpiUtility
+{
+    // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+    private static readonly IntPtr PerMonitorV2 = new IntPtr(-4);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetProcessDpiAwarenessContext(IntPtr dpiContext);
+
+    public static void EnablePerMonitorV2()
+    {
+        SetProcessDpiAwarenessContext(PerMonitorV2);
+    }
+}

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -2,6 +2,8 @@ using PlaywrightWindows.Mcp;
 using PlaywrightWindows.Mcp.Core;
 using PlaywrightWindows.Mcp.Tools;
 
+DpiUtility.EnablePerMonitorV2();
+
 // Create shared services
 var sessionManager = new SessionManager();
 var elementRegistry = new ElementRegistry();

--- a/src/FlaUI.Mcp/Properties/AssemblyInfo.cs
+++ b/src/FlaUI.Mcp/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FlaUI.Mcp.Tests")]

--- a/tests/FlaUI.Mcp.Tests/DpiCaptureTests.cs
+++ b/tests/FlaUI.Mcp.Tests/DpiCaptureTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Threading;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Capturing;
+using FlaUI.UIA3;
+using PlaywrightWindows.Mcp.Core;
+using Xunit;
+
+namespace FlaUI.Mcp.Tests;
+
+/// <summary>
+/// Validates that screenshot capture works correctly when DPI awareness is enabled.
+/// These tests require an interactive desktop session (cannot run headless).
+/// </summary>
+[Collection("Desktop")]
+public class DpiCaptureTests : IDisposable
+{
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(IntPtr hwnd, out RECT lpRect);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT { public int left, top, right, bottom; }
+
+    private Process? _process;
+
+    static DpiCaptureTests()
+    {
+        // Enable DPI awareness once for the test process, before any UIA/GDI calls.
+        DpiUtility.EnablePerMonitorV2();
+    }
+
+    public void Dispose()
+    {
+        if (_process is { HasExited: false })
+        {
+            _process.Kill();
+            _process.WaitForExit(3000);
+        }
+        _process?.Dispose();
+    }
+
+    private (IntPtr hwnd, Process proc) LaunchAndWaitForWindow(string exe, int timeoutMs = 10_000)
+    {
+        var proc = Process.Start(new ProcessStartInfo(exe) { UseShellExecute = true })!;
+        _process = proc;
+        var deadline = Environment.TickCount64 + timeoutMs;
+        while (Environment.TickCount64 < deadline)
+        {
+            Thread.Sleep(500);
+            proc.Refresh();
+            if (proc.MainWindowHandle != IntPtr.Zero)
+                return (proc.MainWindowHandle, proc);
+        }
+        throw new TimeoutException($"{exe} did not produce a MainWindowHandle within {timeoutMs}ms");
+    }
+
+    /// <summary>
+    /// With PER_MONITOR_AWARE_V2 enabled, UIA BoundingRectangle should return
+    /// the same physical-pixel dimensions as GetWindowRect, and Capture.Element
+    /// should produce a bitmap matching those dimensions.
+    /// This test validates the DPI fix at whatever scale factor the system is using.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Desktop")]
+    public void CaptureElement_WithDpiAwareness_MatchesPhysicalWindowSize()
+    {
+        var (hwnd, _) = LaunchAndWaitForWindow("mspaint.exe");
+
+        // Physical pixel size from Win32
+        GetWindowRect(hwnd, out RECT rect);
+        int physicalWidth = rect.right - rect.left;
+        int physicalHeight = rect.bottom - rect.top;
+        Assert.True(physicalWidth > 0 && physicalHeight > 0,
+            $"GetWindowRect returned invalid size: {physicalWidth}x{physicalHeight}");
+
+        // UIA BoundingRectangle (should be physical when caller is DPI-aware)
+        using var automation = new UIA3Automation();
+        var window = automation.FromHandle(hwnd).AsWindow();
+        var bounds = window.BoundingRectangle;
+
+        Assert.Equal(physicalWidth, bounds.Width);
+        Assert.Equal(physicalHeight, bounds.Height);
+
+        // Capture.Element should produce a bitmap at physical pixel dimensions
+        var capture = Capture.Element(window);
+        Assert.Equal(physicalWidth, capture.Bitmap.Width);
+        Assert.Equal(physicalHeight, capture.Bitmap.Height);
+
+        // Verify the capture is not blank (sample pixels)
+        int nonBlank = 0, total = 0;
+        for (int x = 0; x < Math.Min(capture.Bitmap.Width, 200); x += 10)
+            for (int y = 0; y < Math.Min(capture.Bitmap.Height, 200); y += 10)
+            {
+                total++;
+                var px = capture.Bitmap.GetPixel(x, y);
+                if (px.A > 0 && (px.R > 0 || px.G > 0 || px.B > 0))
+                    nonBlank++;
+            }
+
+        Assert.True(nonBlank > total / 4,
+            $"Capture appears mostly blank: only {nonBlank}/{total} sampled pixels were non-black");
+
+        capture.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that the DpiUtility class can be called without throwing.
+    /// SetProcessDpiAwarenessContext is idempotent when called with the same context.
+    /// </summary>
+    [Fact]
+    public void DpiUtility_EnablePerMonitorV2_DoesNotThrow()
+    {
+        // Should not throw even on repeated calls
+        var ex = Record.Exception(() => DpiUtility.EnablePerMonitorV2());
+        Assert.Null(ex);
+    }
+}

--- a/tests/FlaUI.Mcp.Tests/FlaUI.Mcp.Tests.csproj
+++ b/tests/FlaUI.Mcp.Tests/FlaUI.Mcp.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="FlaUI.Core" Version="5.0.0" />
+    <PackageReference Include="FlaUI.UIA3" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FlaUI.Mcp\FlaUI.Mcp.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Problem

`windows_screenshot` produces offset/cropped captures on displays with scaling > 100%. At 150% the capture is offset; at 200% only 1/4 of the window is captured.

**Root cause:** The MCP process does not declare DPI awareness. UIA's `BoundingRectangle` returns virtualized logical coordinates, but `Capture.Element()` captures from the desktop DC in physical pixels. The coordinate mismatch causes incorrect captures.

Fixes #3

## Fix

Call `SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)` as the first statement in the process entry point. This makes UIA return physical pixel coordinates that match the desktop DC.

### Changes
- `src/FlaUI.Mcp/Core/DpiUtility.cs` - P/Invoke wrapper
- `src/FlaUI.Mcp/Program.cs` - call DpiUtility.EnablePerMonitorV2() first
- `CHANGELOG.md` - document the fix
- `FlaUI.Mcp.slnx` - solution file (new)
- `tests/FlaUI.Mcp.Tests/` - xUnit DPI regression test (new)

## Testing

Validated at 150% scaling (144 DPI) on Windows 11. GetWindowRect, UIA BoundingRectangle, and bitmap all match at 3072x1728 physical pixels. `dotnet test` passes (2/2 green).
