### PR TITLE
Add savePath parameter to windows_screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `savePath` parameter for `windows_screenshot` — optionally save captured screenshots to disk as PNG files
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Or using `dotnet run`:
 | `windows_type` | Type text into an element |
 | `windows_fill` | Clear and fill a text field |
 | `windows_get_text` | Get text content of an element |
-| `windows_screenshot` | Capture window/element as PNG |
+| `windows_screenshot` | Capture window/element as PNG (optionally save to file) |
 | `windows_list_windows` | List all open windows |
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |

--- a/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
@@ -42,6 +42,11 @@ public class ScreenshotTool : ToolBase
             {
                 type = "boolean",
                 description = "Capture the entire screen (default: false)"
+            },
+            savePath = new
+            {
+                type = "string",
+                description = "Absolute file path to save the screenshot PNG. If omitted, image is returned inline only."
             }
         }
     };
@@ -51,6 +56,13 @@ public class ScreenshotTool : ToolBase
         var handle = GetStringArgument(arguments, "handle");
         var refId = GetStringArgument(arguments, "ref");
         var fullScreen = GetBoolArgument(arguments, "fullScreen", false);
+        var savePath = GetStringArgument(arguments, "savePath");
+
+        // Validate savePath is absolute if provided
+        if (!string.IsNullOrEmpty(savePath) && !Path.IsPathFullyQualified(savePath))
+        {
+            return Task.FromResult(ErrorResult($"savePath must be an absolute path: {savePath}"));
+        }
 
         try
         {
@@ -105,6 +117,42 @@ public class ScreenshotTool : ToolBase
             using var stream = new MemoryStream();
             capture.Bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
             var imageData = stream.ToArray();
+
+            // Save to file if savePath is provided
+            if (!string.IsNullOrEmpty(savePath))
+            {
+                try
+                {
+                    var directory = Path.GetDirectoryName(savePath);
+                    if (!string.IsNullOrEmpty(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromResult(ErrorResult($"Failed to create directory for screenshot: {ex.Message}"));
+                }
+
+                try
+                {
+                    File.WriteAllBytes(savePath, imageData);
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromResult(ErrorResult($"Failed to save screenshot to {savePath}: {ex.Message}"));
+                }
+
+                var absolutePath = Path.GetFullPath(savePath);
+                return Task.FromResult(new McpToolResult
+                {
+                    Content = new List<McpContent>
+                    {
+                        new() { Type = "text", Text = $"Screenshot saved to {absolutePath}" },
+                        new() { Type = "image", Data = Convert.ToBase64String(imageData), MimeType = "image/png" }
+                    }
+                });
+            }
 
             return Task.FromResult(ImageResult(imageData, "image/png"));
         }


### PR DESCRIPTION
## Summary
- Adds an optional `savePath` parameter to the `windows_screenshot` tool, allowing screenshots to be saved directly to disk as PNG files
- Validates that the path is absolute, auto-creates directories, and returns both a text confirmation and the inline image
- Updates CHANGELOG.md and README.md per contributing guidelines

## Test plan
- [ ] Call `windows_screenshot` without `savePath` — verify existing behavior is unchanged (inline image returned)
- [ ] Call `windows_screenshot` with `savePath` set to an absolute path — verify file is saved and response includes both text and image
- [ ] Call `windows_screenshot` with a relative `savePath` — verify it returns an error
- [ ] Call `windows_screenshot` with a `savePath` whose parent directory doesn't exist — verify directory is created automatically