### PR TITLE
Fix screenshot wrong-window capture and improve WinForms text extraction

### DIFF
--- a/src/FlaUI.Mcp/Tools/GetTextTool.cs
+++ b/src/FlaUI.Mcp/Tools/GetTextTool.cs
@@ -59,6 +59,22 @@ public class GetTextTool : ToolBase
                 text = element.Patterns.Value.Pattern.Value.ValueOrDefault;
             }
 
+            // For ComboBox, use Selection pattern to get the selected item text
+            if (string.IsNullOrEmpty(text) && element.Patterns.Selection.IsSupported)
+            {
+                var selected = element.Patterns.Selection.Pattern.Selection.ValueOrDefault;
+                if (selected != null && selected.Length > 0)
+                {
+                    text = selected[0].Properties.Name.ValueOrDefault;
+                }
+            }
+
+            // Try LegacyIAccessible (reliable for WinForms ComboBox)
+            if (string.IsNullOrEmpty(text) && element.Patterns.LegacyIAccessible.IsSupported)
+            {
+                text = element.Patterns.LegacyIAccessible.Pattern.Value.ValueOrDefault;
+            }
+
             // Fall back to Name property
             if (string.IsNullOrEmpty(text))
             {

--- a/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
@@ -46,7 +46,7 @@ public class ScreenshotTool : ToolBase
         }
     };
 
-    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
     {
         var handle = GetStringArgument(arguments, "handle");
         var refId = GetStringArgument(arguments, "ref");
@@ -65,7 +65,7 @@ public class ScreenshotTool : ToolBase
                 var element = _elementRegistry.GetElement(refId);
                 if (element == null)
                 {
-                    return Task.FromResult(ErrorResult($"Element not found: {refId}"));
+                    return ErrorResult($"Element not found: {refId}");
                 }
                 capture = Capture.Element(element);
             }
@@ -74,8 +74,11 @@ public class ScreenshotTool : ToolBase
                 var window = _sessionManager.GetWindow(handle);
                 if (window == null)
                 {
-                    return Task.FromResult(ErrorResult($"Window not found: {handle}"));
+                    return ErrorResult($"Window not found: {handle}");
                 }
+                // Focus the window first to ensure we capture the correct one
+                window.Focus();
+                await Task.Delay(200);
                 capture = Capture.Element(window);
             }
             else
@@ -84,7 +87,7 @@ public class ScreenshotTool : ToolBase
                 var focusedElement = _sessionManager.Automation.FocusedElement();
                 if (focusedElement == null)
                 {
-                    return Task.FromResult(ErrorResult("No focused window found"));
+                    return ErrorResult("No focused window found");
                 }
 
                 // Walk up to find the window
@@ -96,21 +99,24 @@ public class ScreenshotTool : ToolBase
 
                 if (current == null)
                 {
-                    return Task.FromResult(ErrorResult("Could not find window for focused element"));
+                    return ErrorResult("Could not find window for focused element");
                 }
 
                 capture = Capture.Element(current);
             }
 
             using var stream = new MemoryStream();
-            capture.Bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+            using (capture)
+            {
+                capture.Bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+            }
             var imageData = stream.ToArray();
 
-            return Task.FromResult(ImageResult(imageData, "image/png"));
+            return ImageResult(imageData, "image/png");
         }
         catch (Exception ex)
         {
-            return Task.FromResult(ErrorResult($"Failed to capture screenshot: {ex.Message}"));
+            return ErrorResult($"Failed to capture screenshot: {ex.Message}");
         }
     }
 }


### PR DESCRIPTION
## Summary

- **ScreenshotTool**: Focus the target window before capturing when a `handle` is provided, preventing screenshots of the wrong window when multiple windows overlap. Also disposes `CaptureImage` after saving to prevent GDI handle leaks in long-running sessions.
- **GetTextTool**: Add `Selection` pattern and `LegacyIAccessible` pattern fallbacks for WinForms controls (especially ComboBox), which often don't expose values through the standard `Value` or `Text` patterns. Both are tried before the `Name` property fallback, which can incorrectly return associated label text.

## Motivation

Found during automated UI testing of WinForms applications:
1. `windows_screenshot` with an explicit `handle` frequently captured the wrong window (e.g., another overlapping app) because no focus was set before capture
2. `windows_get_text` on WinForms ComboBox controls returned the associated label text (e.g., "Entity 1:") instead of the selected item value

## Test plan

- [ ] Call `windows_screenshot` with a specific window handle while another window overlaps — should capture the correct window
- [ ] Call `windows_get_text` on a WinForms ComboBox with a selected item — should return the selected item text, not the label
- [ ] Run multiple screenshot captures in sequence — no GDI handle accumulation