### PR TITLE
Add global timeout wrapper to prevent modal dialog hangs

### DIFF
--- a/src/FlaUI.Mcp/Core/SessionManager.cs
+++ b/src/FlaUI.Mcp/Core/SessionManager.cs
@@ -13,7 +13,6 @@ public class SessionManager : IDisposable
     private readonly UIA3Automation _automation;
     private readonly Dictionary<string, FlaUIApplication> _applications = new();
     private readonly Dictionary<string, Window> _windows = new();
-    private int _appCounter = 0;
     private int _windowCounter = 0;
 
     public SessionManager()

--- a/src/FlaUI.Mcp/Mcp/McpServer.cs
+++ b/src/FlaUI.Mcp/Mcp/McpServer.cs
@@ -8,7 +8,6 @@ namespace PlaywrightWindows.Mcp;
 public class McpServer
 {
     private readonly ToolRegistry _toolRegistry;
-    private bool _initialized = false;
 
     public McpServer(ToolRegistry toolRegistry)
     {
@@ -87,7 +86,7 @@ public class McpServer
 
     private McpInitializeResult HandleInitialize(JsonRpcRequest request)
     {
-        _initialized = true;
+        // Server initialization complete
         return new McpInitializeResult
         {
             ProtocolVersion = "2024-11-05",

--- a/src/FlaUI.Mcp/Mcp/ToolRegistry.cs
+++ b/src/FlaUI.Mcp/Mcp/ToolRegistry.cs
@@ -19,6 +19,8 @@ public class ToolRegistry
         return _tools.Values.Select(t => t.GetDefinition()).ToList();
     }
 
+    private const int DefaultTimeoutMs = 30000;
+
     public async Task<McpToolResult> ExecuteToolAsync(string name, JsonElement? arguments)
     {
         if (!_tools.TryGetValue(name, out var tool))
@@ -35,7 +37,29 @@ public class ToolRegistry
 
         try
         {
-            return await tool.ExecuteAsync(arguments);
+            var toolTask = tool.ExecuteAsync(arguments);
+            var timeoutTask = Task.Delay(DefaultTimeoutMs);
+
+            if (await Task.WhenAny(toolTask, timeoutTask) == timeoutTask)
+            {
+                // Observe the abandoned task's exception to avoid UnobservedTaskException
+                _ = toolTask.ContinueWith(
+                    t => { _ = t.Exception; },
+                    TaskContinuationOptions.OnlyOnFaulted);
+
+                return new McpToolResult
+                {
+                    Content = new List<McpContent>
+                    {
+                        new() { Type = "text", Text = $"Tool '{name}' timed out after {DefaultTimeoutMs}ms. " +
+                            "A modal dialog (e.g., file Open/Save) may be blocking the UI. " +
+                            "Try using windows_file_dialog to dismiss the dialog first." }
+                    },
+                    IsError = true
+                };
+            }
+
+            return await toolTask;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

- **ToolRegistry**: Wrap all tool execution with a 30-second timeout using `Task.WhenAny`. When a tool hangs (typically because a modal dialog is blocking the UI thread), the timeout fires and returns an actionable error message suggesting `windows_file_dialog` to dismiss the dialog.
- **Abandoned task observation**: After timeout, the original task's exception is observed to prevent thread pool leaks.
- **Cleanup**: Remove unused `_appCounter` field (SessionManager) and `_initialized` field (McpServer) to fix CS0414 warnings.

## Motivation

Fixes #7. When a WinForms application opens a modal file dialog (`OpenFileDialog.ShowDialog()`), it blocks the UI thread. Any FlaUI tool that queries the UIA tree (e.g., `windows_click`, `windows_snapshot`) hangs indefinitely because UIA COM calls route through the blocked thread. Without a timeout, the MCP server becomes unresponsive.

The 30-second timeout provides a safety net: the tool returns an error, the MCP server stays responsive, and the agent can use `windows_file_dialog` (or other strategies) to dismiss the blocking dialog.

## Test plan

- [ ] Call `windows_click` on a WinForms button that opens `OpenFileDialog` — should return timeout error after 30s instead of hanging forever
- [ ] Call `windows_snapshot` on a non-modal window — should complete normally (well under 30s)
- [ ] Verify the timeout error message mentions `windows_file_dialog` as a workaround