### PR TITLE
Add manual build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,22 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to create, for example v0.1.1'
+        required: true
+        type: string
+      draft:
+        description: 'Create the release as a draft'
+        required: true
+        default: true
+        type: boolean
+      prerelease:
+        description: 'Mark the release as a prerelease'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   release:
@@ -24,21 +40,28 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Determine release version
+      id: release
+      shell: pwsh
+      run: |
+        if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+          $tag = "${{ inputs.tag_name }}"
+        } else {
+          $tag = "${{ github.ref_name }}"
+        }
+
+        if ($tag -notmatch '^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$') {
+          throw "Release tag must look like v1.2.3 or v1.2.3-prerelease; got '$tag'."
+        }
+
+        $version = $tag.Substring(1)
+        "tag=$tag" >> $env:GITHUB_OUTPUT
+        "version=$version" >> $env:GITHUB_OUTPUT
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
-
-    - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1
-      with:
-        versionSpec: '5.x'
-
-    - name: Determine Version
-      id: gitversion
-      uses: gittools/actions/gitversion/execute@v1
-      with:
-        useConfigFile: true
 
     - name: Restore dependencies
       run: dotnet restore src/FlaUI.Mcp/FlaUI.Mcp.csproj
@@ -50,7 +73,7 @@ jobs:
           --runtime ${{ matrix.runtime }} `
           --self-contained true `
           --output ./publish/self-contained `
-          -p:Version=${{ steps.gitversion.outputs.semVer }} `
+          -p:Version=${{ steps.release.outputs.version }} `
           -p:PublishSingleFile=true `
           -p:IncludeNativeLibrariesForSelfExtract=true
 
@@ -61,12 +84,12 @@ jobs:
           --runtime ${{ matrix.runtime }} `
           --self-contained false `
           --output ./publish/framework-dependent `
-          -p:Version=${{ steps.gitversion.outputs.semVer }}
+          -p:Version=${{ steps.release.outputs.version }}
 
     - name: Create ZIP archives
       run: |
-        Compress-Archive -Path ./publish/self-contained/* -DestinationPath ./${{ matrix.artifact_name }}-${{ steps.gitversion.outputs.semVer }}-self-contained.zip
-        Compress-Archive -Path ./publish/framework-dependent/* -DestinationPath ./${{ matrix.artifact_name }}-${{ steps.gitversion.outputs.semVer }}.zip
+        Compress-Archive -Path ./publish/self-contained/* -DestinationPath ./${{ matrix.artifact_name }}-${{ steps.release.outputs.version }}-self-contained.zip
+        Compress-Archive -Path ./publish/framework-dependent/* -DestinationPath ./${{ matrix.artifact_name }}-${{ steps.release.outputs.version }}.zip
       shell: pwsh
 
     - name: Upload Release Artifacts
@@ -86,16 +109,29 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1
-      with:
-        versionSpec: '5.x'
+    - name: Determine release version
+      id: release
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          tag="${{ inputs.tag_name }}"
+          draft="${{ inputs.draft }}"
+          prerelease="${{ inputs.prerelease }}"
+        else
+          tag="${GITHUB_REF_NAME}"
+          draft="false"
+          prerelease="false"
+        fi
 
-    - name: Determine Version
-      id: gitversion
-      uses: gittools/actions/gitversion/execute@v1
-      with:
-        useConfigFile: true
+        if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          echo "Release tag must look like v1.2.3 or v1.2.3-prerelease; got '$tag'." >&2
+          exit 1
+        fi
+
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+        echo "draft=$draft" >> "$GITHUB_OUTPUT"
+        echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
 
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -108,11 +144,13 @@ jobs:
       run: ls -la artifacts/
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
-        name: FlaUI-MCP v${{ steps.gitversion.outputs.semVer }}
+        tag_name: ${{ steps.release.outputs.tag }}
+        target_commitish: ${{ github.sha }}
+        name: FlaUI-MCP ${{ steps.release.outputs.tag }}
         body: |
-          ## FlaUI-MCP v${{ steps.gitversion.outputs.semVer }}
+          ## FlaUI-MCP ${{ steps.release.outputs.tag }}
           
           An MCP server for Windows desktop automation using accessibility APIs.
           
@@ -144,5 +182,5 @@ jobs:
           
           See [README](https://github.com/shanselman/FlaUI-MCP#readme) for full documentation.
         files: artifacts/*.zip
-        draft: false
-        prerelease: false
+        draft: ${{ steps.release.outputs.draft }}
+        prerelease: ${{ steps.release.outputs.prerelease }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,16 @@ cd src/FlaUI.Mcp
 dotnet build
 ```
 
+The same build can be run from GitHub Actions with the **Build** workflow's
+manual dispatch button. Pull requests and pushes to `main` also run the build.
+
+### Releasing
+
+Releases are created by the **Release** workflow. Maintainers can either push a
+semantic version tag such as `v0.1.1`, or run the workflow manually and provide
+the tag name. Manual releases default to draft so the generated x64 and ARM64
+ZIP files can be reviewed before publishing.
+
 ### Testing
 
 ```powershell


### PR DESCRIPTION
## Summary
- add manual dispatch support to the Build workflow
- add manual release dispatch with tag, draft, and prerelease inputs
- derive release artifact versions from the `v*` tag for predictable manual releases
- document maintainer build/release workflow in CONTRIBUTING

## Validation
- `dotnet restore src\FlaUI.Mcp\FlaUI.Mcp.csproj`
- `dotnet build src\FlaUI.Mcp\FlaUI.Mcp.csproj --configuration Release --no-restore`
- parsed `.github\workflows\build.yml` and `.github\workflows\release.yml` with YamlDotNet
- smoke-published win-x64 self-contained and win-arm64 framework-dependent artifacts

Addresses the build/release automation gap tracked in the new maintainer issue.