### PR TITLE
Improve text extraction and dispose screenshots

### DIFF
--- a/src/FlaUI.Mcp/Tools/GetTextTool.cs
+++ b/src/FlaUI.Mcp/Tools/GetTextTool.cs
@@ -59,6 +59,20 @@ public class GetTextTool : ToolBase
                 text = element.Patterns.Value.Pattern.Value.ValueOrDefault;
             }
 
+            if (string.IsNullOrEmpty(text) && element.Patterns.Selection.IsSupported)
+            {
+                var selected = element.Patterns.Selection.Pattern.Selection.ValueOrDefault;
+                if (selected != null && selected.Length > 0)
+                {
+                    text = selected[0].Properties.Name.ValueOrDefault;
+                }
+            }
+
+            if (string.IsNullOrEmpty(text) && element.Patterns.LegacyIAccessible.IsSupported)
+            {
+                text = element.Patterns.LegacyIAccessible.Pattern.Value.ValueOrDefault;
+            }
+
             // Fall back to Name property
             if (string.IsNullOrEmpty(text))
             {

--- a/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
@@ -102,9 +102,13 @@ public class ScreenshotTool : ToolBase
                 capture = Capture.Element(current);
             }
 
-            using var stream = new MemoryStream();
-            capture.Bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-            var imageData = stream.ToArray();
+            byte[] imageData;
+            using (capture)
+            {
+                using var stream = new MemoryStream();
+                capture.Bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+                imageData = stream.ToArray();
+            }
 
             return Task.FromResult(ImageResult(imageData, "image/png"));
         }


### PR DESCRIPTION
## Summary
- add Selection-pattern fallback for controls such as read-only ComboBox values
- add LegacyIAccessible fallback for WinForms controls that do not expose standard Value/Text patterns
- dispose `CaptureImage` after encoding screenshots to avoid GDI handle leaks

This intentionally takes only the safe parts of the original screenshot/text PR. It does **not** include focus-before-capture behavior, because that changes screenshot semantics and conflicts with background screenshot work.

## Validation
- `dotnet build src\FlaUI.Mcp\FlaUI.Mcp.csproj --configuration Release`
- MCP screenshot smoke test against Notepad through JSON-RPC:
  - launched Notepad
  - captured `windows_screenshot` by handle
  - verified image content was returned
  - closed Notepad

Original contributor credited in the commit.