### PR TITLE
Add opt-in background screenshot capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solution file (`FlaUI.Mcp.slnx`)
 - xUnit test project (`tests/FlaUI.Mcp.Tests`) with DPI regression test
 - `windows_send_keys` MCP tool for sending key presses and key chords.
+- Opt-in `background` mode for `windows_screenshot` handle captures, with blank-frame fallback to the normal capture path.
 
 ## [0.1.0] - 2024-02-02
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Or using `dotnet run`:
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
 
+`windows_screenshot` supports an optional `background: true` argument when a
+window `handle` is provided. This uses native background capture when available
+and falls back to the normal screenshot path if Windows returns a blank frame.
+
 ## How It Works
 
 ### The Accessibility Snapshot

--- a/src/FlaUI.Mcp/Core/NativeWindowCapture.cs
+++ b/src/FlaUI.Mcp/Core/NativeWindowCapture.cs
@@ -1,0 +1,112 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using FlaUI.Core.AutomationElements;
+
+namespace PlaywrightWindows.Mcp.Core;
+
+internal static class NativeWindowCapture
+{
+    private const uint PW_RENDERFULLCONTENT = 0x00000002;
+
+    public static bool TryCaptureWindow(Window window, out byte[] imageData, out string? failureReason)
+    {
+        imageData = Array.Empty<byte>();
+        failureReason = null;
+
+        if (!window.Properties.NativeWindowHandle.TryGetValue(out var nativeWindowHandle) || nativeWindowHandle == 0)
+        {
+            failureReason = "No native window handle available";
+            return false;
+        }
+
+        var hwnd = new IntPtr(nativeWindowHandle);
+        if (!GetWindowRect(hwnd, out var rect))
+        {
+            failureReason = "Could not read window bounds";
+            return false;
+        }
+
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+        if (width <= 0 || height <= 0)
+        {
+            failureReason = "Window has invalid bounds";
+            return false;
+        }
+
+        try
+        {
+            using var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            using var graphics = Graphics.FromImage(bitmap);
+            var hdc = graphics.GetHdc();
+
+            try
+            {
+                if (!PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT))
+                {
+                    failureReason = "PrintWindow failed";
+                    return false;
+                }
+            }
+            finally
+            {
+                graphics.ReleaseHdc(hdc);
+            }
+
+            if (IsBlankOrNearlyBlank(bitmap))
+            {
+                failureReason = "PrintWindow produced a blank image";
+                return false;
+            }
+
+            using var stream = new MemoryStream();
+            bitmap.Save(stream, ImageFormat.Png);
+            imageData = stream.ToArray();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            failureReason = ex.Message;
+            return false;
+        }
+    }
+
+    internal static bool IsBlankOrNearlyBlank(Bitmap bitmap)
+    {
+        const int maxSamples = 1024;
+        var stepX = Math.Max(1, bitmap.Width / 32);
+        var stepY = Math.Max(1, bitmap.Height / 32);
+        var samples = 0;
+
+        for (var y = 0; y < bitmap.Height && samples < maxSamples; y += stepY)
+        {
+            for (var x = 0; x < bitmap.Width && samples < maxSamples; x += stepX)
+            {
+                samples++;
+                var pixel = bitmap.GetPixel(x, y);
+                if (pixel.A > 0 && (pixel.R > 8 || pixel.G > 8 || pixel.B > 8))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return samples > 0;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+}

--- a/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
@@ -42,6 +42,11 @@ public class ScreenshotTool : ToolBase
             {
                 type = "boolean",
                 description = "Capture the entire screen (default: false)"
+            },
+            background = new
+            {
+                type = "boolean",
+                description = "Use native background window capture for a window handle, falling back to normal capture if unavailable (default: false)"
             }
         }
     };
@@ -51,10 +56,16 @@ public class ScreenshotTool : ToolBase
         var handle = GetStringArgument(arguments, "handle");
         var refId = GetStringArgument(arguments, "ref");
         var fullScreen = GetBoolArgument(arguments, "fullScreen", false);
+        var background = GetBoolArgument(arguments, "background", false);
 
         try
         {
             CaptureImage capture;
+
+            if (background && (fullScreen || !string.IsNullOrEmpty(refId) || string.IsNullOrEmpty(handle)))
+            {
+                return Task.FromResult(ErrorResult("background capture requires a window handle and cannot be combined with ref or fullScreen"));
+            }
 
             if (fullScreen)
             {
@@ -76,6 +87,12 @@ public class ScreenshotTool : ToolBase
                 {
                     return Task.FromResult(ErrorResult($"Window not found: {handle}"));
                 }
+
+                if (background && NativeWindowCapture.TryCaptureWindow(window, out var backgroundImage, out _))
+                {
+                    return Task.FromResult(ImageResult(backgroundImage, "image/png"));
+                }
+
                 capture = Capture.Element(window);
             }
             else

--- a/tests/FlaUI.Mcp.Tests/NativeWindowCaptureTests.cs
+++ b/tests/FlaUI.Mcp.Tests/NativeWindowCaptureTests.cs
@@ -1,0 +1,29 @@
+using System.Drawing;
+using PlaywrightWindows.Mcp.Core;
+using Xunit;
+
+namespace FlaUI.Mcp.Tests;
+
+public class NativeWindowCaptureTests
+{
+    [Fact]
+    public void IsBlankOrNearlyBlank_ReturnsTrue_ForBlackBitmap()
+    {
+        using var bitmap = new Bitmap(16, 16);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(Color.Black);
+
+        Assert.True(NativeWindowCapture.IsBlankOrNearlyBlank(bitmap));
+    }
+
+    [Fact]
+    public void IsBlankOrNearlyBlank_ReturnsFalse_ForVisibleContent()
+    {
+        using var bitmap = new Bitmap(16, 16);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(Color.Black);
+        bitmap.SetPixel(8, 8, Color.White);
+
+        Assert.False(NativeWindowCapture.IsBlankOrNearlyBlank(bitmap));
+    }
+}


### PR DESCRIPTION
## Summary
- add native `PrintWindow` capture for `windows_screenshot` only when `background: true` is supplied with a window handle
- keep default screenshot behavior unchanged
- detect blank native captures and fall back to the normal capture path
- reject invalid `background` combinations such as `fullScreen` or element `ref`
- add tests for blank-frame detection

This reworks the original background screenshot contribution so it avoids silently returning black frames and reconciles with the existing screenshot behavior.

## Validation
- `dotnet build FlaUI.Mcp.slnx --configuration Release`
- `dotnet test tests\FlaUI.Mcp.Tests\FlaUI.Mcp.Tests.csproj --configuration Release --no-build`
- MCP smoke test against Notepad through JSON-RPC:
  - launched Notepad
  - captured `windows_screenshot` with `background: true`
  - verified image content was returned
  - verified invalid `background + fullScreen` arguments are rejected
  - closed Notepad

Original contributor credited in the commit.