### PR TITLE
Add safe screenshot save path support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - xUnit test project (`tests/FlaUI.Mcp.Tests`) with DPI regression test
 - `windows_send_keys` MCP tool for sending key presses and key chords.
 - Opt-in `background` mode for `windows_screenshot` handle captures, with blank-frame fallback to the normal capture path.
+- `savePath` and `overwrite` options for `windows_screenshot`, with local PNG path validation and atomic writes.
 
 ## [0.1.0] - 2024-02-02
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Or using `dotnet run`:
 `windows_screenshot` supports an optional `background: true` argument when a
 window `handle` is provided. This uses native background capture when available
 and falls back to the normal screenshot path if Windows returns a blank frame.
+It can also save screenshots with `savePath`, which must be an absolute local
+`.png` path. Existing files are not replaced unless `overwrite: true` is set.
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/ScreenshotTool.cs
@@ -47,6 +47,16 @@ public class ScreenshotTool : ToolBase
             {
                 type = "boolean",
                 description = "Use native background window capture for a window handle, falling back to normal capture if unavailable (default: false)"
+            },
+            savePath = new
+            {
+                type = "string",
+                description = "Absolute local .png file path to save the screenshot. UNC and device paths are rejected."
+            },
+            overwrite = new
+            {
+                type = "boolean",
+                description = "Allow savePath to replace an existing file (default: false)"
             }
         }
     };
@@ -57,6 +67,13 @@ public class ScreenshotTool : ToolBase
         var refId = GetStringArgument(arguments, "ref");
         var fullScreen = GetBoolArgument(arguments, "fullScreen", false);
         var background = GetBoolArgument(arguments, "background", false);
+        var savePath = GetStringArgument(arguments, "savePath");
+        var overwrite = GetBoolArgument(arguments, "overwrite", false);
+
+        if (!TryNormalizeSavePath(savePath, overwrite, out var normalizedSavePath, out var pathError))
+        {
+            return Task.FromResult(ErrorResult(pathError));
+        }
 
         try
         {
@@ -90,7 +107,7 @@ public class ScreenshotTool : ToolBase
 
                 if (background && NativeWindowCapture.TryCaptureWindow(window, out var backgroundImage, out _))
                 {
-                    return Task.FromResult(ImageResult(backgroundImage, "image/png"));
+                    return Task.FromResult(BuildScreenshotResult(backgroundImage, normalizedSavePath, overwrite));
                 }
 
                 capture = Capture.Element(window);
@@ -127,11 +144,104 @@ public class ScreenshotTool : ToolBase
                 imageData = stream.ToArray();
             }
 
-            return Task.FromResult(ImageResult(imageData, "image/png"));
+            return Task.FromResult(BuildScreenshotResult(imageData, normalizedSavePath, overwrite));
         }
         catch (Exception ex)
         {
             return Task.FromResult(ErrorResult($"Failed to capture screenshot: {ex.Message}"));
         }
+    }
+
+    internal static bool TryNormalizeSavePath(string? savePath, bool overwrite, out string? normalizedPath, out string error)
+    {
+        normalizedPath = null;
+        error = "";
+
+        if (string.IsNullOrWhiteSpace(savePath))
+        {
+            return true;
+        }
+
+        if (!Path.IsPathFullyQualified(savePath))
+        {
+            error = $"savePath must be an absolute local path: {savePath}";
+            return false;
+        }
+
+        if (savePath.StartsWith(@"\\") || savePath.StartsWith(@"\\?\") || savePath.StartsWith(@"\\.\"))
+        {
+            error = "savePath must be a local drive path; UNC and device paths are not allowed";
+            return false;
+        }
+
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(savePath);
+        }
+        catch (Exception ex)
+        {
+            error = $"savePath is invalid: {ex.Message}";
+            return false;
+        }
+
+        if (!string.Equals(Path.GetExtension(fullPath), ".png", StringComparison.OrdinalIgnoreCase))
+        {
+            error = "savePath must end with .png";
+            return false;
+        }
+
+        if (File.Exists(fullPath) && !overwrite)
+        {
+            error = $"savePath already exists; pass overwrite=true to replace it: {fullPath}";
+            return false;
+        }
+
+        normalizedPath = fullPath;
+        return true;
+    }
+
+    private static McpToolResult BuildScreenshotResult(byte[] imageData, string? savePath, bool overwrite)
+    {
+        if (string.IsNullOrEmpty(savePath))
+        {
+            return ImageResult(imageData, "image/png");
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(savePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var tempPath = Path.Combine(directory ?? Directory.GetCurrentDirectory(), $"{Path.GetFileName(savePath)}.{Guid.NewGuid():N}.tmp");
+            try
+            {
+                File.WriteAllBytes(tempPath, imageData);
+                File.Move(tempPath, savePath, overwrite);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            return ErrorResult($"Failed to save screenshot to {savePath}: {ex.Message}");
+        }
+
+        return new McpToolResult
+        {
+            Content = new List<McpContent>
+            {
+                new() { Type = "text", Text = $"Screenshot saved to {savePath}" },
+                new() { Type = "image", Data = Convert.ToBase64String(imageData), MimeType = "image/png" }
+            }
+        };
     }
 }

--- a/tests/FlaUI.Mcp.Tests/ScreenshotToolSavePathTests.cs
+++ b/tests/FlaUI.Mcp.Tests/ScreenshotToolSavePathTests.cs
@@ -1,0 +1,54 @@
+using PlaywrightWindows.Mcp.Tools;
+using Xunit;
+
+namespace FlaUI.Mcp.Tests;
+
+public class ScreenshotToolSavePathTests
+{
+    [Fact]
+    public void TryNormalizeSavePath_RejectsRelativePath()
+    {
+        var ok = ScreenshotTool.TryNormalizeSavePath("capture.png", overwrite: false, out _, out var error);
+
+        Assert.False(ok);
+        Assert.Contains("absolute", error);
+    }
+
+    [Fact]
+    public void TryNormalizeSavePath_RejectsUncPath()
+    {
+        var ok = ScreenshotTool.TryNormalizeSavePath(@"\\server\share\capture.png", overwrite: false, out _, out var error);
+
+        Assert.False(ok);
+        Assert.Contains("UNC", error);
+    }
+
+    [Fact]
+    public void TryNormalizeSavePath_RejectsNonPngPath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "capture.txt");
+        var ok = ScreenshotTool.TryNormalizeSavePath(path, overwrite: false, out _, out var error);
+
+        Assert.False(ok);
+        Assert.Contains(".png", error);
+    }
+
+    [Fact]
+    public void TryNormalizeSavePath_RejectsExistingFileWithoutOverwrite()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.png");
+        File.WriteAllText(path, "");
+
+        try
+        {
+            var ok = ScreenshotTool.TryNormalizeSavePath(path, overwrite: false, out _, out var error);
+
+            Assert.False(ok);
+            Assert.Contains("overwrite=true", error);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `savePath` support to `windows_screenshot`
- add `overwrite` opt-in for replacing existing files
- require absolute local `.png` paths
- reject UNC/device paths and existing files by default
- write via temp file then atomic move
- add save-path validation tests

This reworks the original save-path contribution with guardrails for the MCP trust boundary.

## Validation
- `dotnet build FlaUI.Mcp.slnx --configuration Release`
- `dotnet test tests\FlaUI.Mcp.Tests\FlaUI.Mcp.Tests.csproj --configuration Release --no-build`
- MCP smoke test against Notepad through JSON-RPC:
  - saved a screenshot to an absolute local `.png` path
  - verified the file was created
  - verified existing file save is rejected without `overwrite`
  - verified invalid relative/non-PNG path is rejected
  - closed Notepad

Original contributor credited in the commit.