### PR TITLE
Add global tool execution timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Screenshots are now correct on scaled displays (DPI > 100%). Added `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` as the first call in the process entry point so UIA coordinates match physical pixels.
+- Tool execution now times out after 30 seconds instead of hanging indefinitely when UI Automation blocks.
 
 ### Added
 - Solution file (`FlaUI.Mcp.slnx`)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ and falls back to the normal screenshot path if Windows returns a blank frame.
 It can also save screenshots with `savePath`, which must be an absolute local
 `.png` path. Existing files are not replaced unless `overwrite: true` is set.
 
+Tool calls have a 30-second timeout so a blocked UI Automation provider or modal
+dialog returns an actionable error instead of hanging the MCP server forever.
+
 ## How It Works
 
 ### The Accessibility Snapshot

--- a/src/FlaUI.Mcp/Core/SessionManager.cs
+++ b/src/FlaUI.Mcp/Core/SessionManager.cs
@@ -13,7 +13,6 @@ public class SessionManager : IDisposable
     private readonly UIA3Automation _automation;
     private readonly Dictionary<string, FlaUIApplication> _applications = new();
     private readonly Dictionary<string, Window> _windows = new();
-    private int _appCounter = 0;
     private int _windowCounter = 0;
 
     public SessionManager()

--- a/src/FlaUI.Mcp/Mcp/McpServer.cs
+++ b/src/FlaUI.Mcp/Mcp/McpServer.cs
@@ -8,7 +8,6 @@ namespace PlaywrightWindows.Mcp;
 public class McpServer
 {
     private readonly ToolRegistry _toolRegistry;
-    private bool _initialized = false;
 
     public McpServer(ToolRegistry toolRegistry)
     {
@@ -87,7 +86,6 @@ public class McpServer
 
     private McpInitializeResult HandleInitialize(JsonRpcRequest request)
     {
-        _initialized = true;
         return new McpInitializeResult
         {
             ProtocolVersion = "2024-11-05",

--- a/src/FlaUI.Mcp/Mcp/ToolRegistry.cs
+++ b/src/FlaUI.Mcp/Mcp/ToolRegistry.cs
@@ -8,6 +8,16 @@ namespace PlaywrightWindows.Mcp;
 public class ToolRegistry
 {
     private readonly Dictionary<string, ITool> _tools = new();
+    private readonly TimeSpan _toolTimeout;
+
+    public ToolRegistry(TimeSpan? toolTimeout = null)
+    {
+        _toolTimeout = toolTimeout ?? TimeSpan.FromSeconds(30);
+        if (_toolTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(toolTimeout), "Tool timeout must be greater than zero.");
+        }
+    }
 
     public void RegisterTool(ITool tool)
     {
@@ -35,7 +45,32 @@ public class ToolRegistry
 
         try
         {
-            return await tool.ExecuteAsync(arguments);
+            var toolTask = Task.Run(() => tool.ExecuteAsync(arguments));
+            var timeoutTask = Task.Delay(_toolTimeout);
+
+            if (await Task.WhenAny(toolTask, timeoutTask) == timeoutTask)
+            {
+                _ = toolTask.ContinueWith(
+                    task => { _ = task.Exception; },
+                    TaskContinuationOptions.OnlyOnFaulted);
+
+                return new McpToolResult
+                {
+                    Content = new List<McpContent>
+                    {
+                        new()
+                        {
+                            Type = "text",
+                            Text = $"Tool '{name}' timed out after {(int)_toolTimeout.TotalMilliseconds}ms. " +
+                                   "A modal dialog or blocked UI Automation provider may still be running in the background. " +
+                                   "Dismiss the blocking UI and retry the request."
+                        }
+                    },
+                    IsError = true
+                };
+            }
+
+            return await toolTask;
         }
         catch (Exception ex)
         {

--- a/tests/FlaUI.Mcp.Tests/ToolRegistryTimeoutTests.cs
+++ b/tests/FlaUI.Mcp.Tests/ToolRegistryTimeoutTests.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+using System.Text.Json;
+using PlaywrightWindows.Mcp;
+using Xunit;
+
+namespace FlaUI.Mcp.Tests;
+
+public class ToolRegistryTimeoutTests
+{
+    [Fact]
+    public async Task ExecuteToolAsync_TimesOutSynchronousToolBody()
+    {
+        var registry = new ToolRegistry(TimeSpan.FromMilliseconds(50));
+        registry.RegisterTool(new BlockingTool(TimeSpan.FromMilliseconds(500)));
+
+        var sw = Stopwatch.StartNew();
+        var result = await registry.ExecuteToolAsync("blocking", arguments: null);
+        sw.Stop();
+
+        Assert.True(result.IsError);
+        Assert.Contains("timed out", result.Content[0].Text);
+        Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(400), $"Timeout returned too slowly: {sw.Elapsed}");
+    }
+
+    [Fact]
+    public async Task ExecuteToolAsync_ReturnsSuccessfulToolResult()
+    {
+        var registry = new ToolRegistry(TimeSpan.FromSeconds(1));
+        registry.RegisterTool(new SuccessfulTool());
+
+        var result = await registry.ExecuteToolAsync("successful", arguments: null);
+
+        Assert.NotEqual(true, result.IsError);
+        Assert.Equal("ok", result.Content[0].Text);
+    }
+
+    private sealed class BlockingTool : ITool
+    {
+        private readonly TimeSpan _delay;
+
+        public BlockingTool(TimeSpan delay)
+        {
+            _delay = delay;
+        }
+
+        public string Name => "blocking";
+
+        public McpTool GetDefinition() => new()
+        {
+            Name = Name,
+            Description = "Blocks synchronously",
+            InputSchema = new { type = "object" }
+        };
+
+        public Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+        {
+            Thread.Sleep(_delay);
+            return Task.FromResult(new McpToolResult
+            {
+                Content = new List<McpContent> { new() { Type = "text", Text = "late" } }
+            });
+        }
+    }
+
+    private sealed class SuccessfulTool : ITool
+    {
+        public string Name => "successful";
+
+        public McpTool GetDefinition() => new()
+        {
+            Name = Name,
+            Description = "Succeeds",
+            InputSchema = new { type = "object" }
+        };
+
+        public Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+        {
+            return Task.FromResult(new McpToolResult
+            {
+                Content = new List<McpContent> { new() { Type = "text", Text = "ok" } }
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a 30-second global timeout for tool execution
- run tool bodies on a worker task before applying the timeout so synchronous UIA hangs can return an MCP error
- remove misleading guidance for a nonexistent `windows_file_dialog` tool
- remove unused warning-producing fields
- add regression tests proving a synchronous blocking tool times out

This reimplements the timeout PR so it handles the current synchronous tool model.

## Validation
- `dotnet build FlaUI.Mcp.slnx --configuration Release`
- `dotnet test tests\FlaUI.Mcp.Tests\FlaUI.Mcp.Tests.csproj --configuration Release --no-build`
- `dotnet test tests\FlaUI.Mcp.IntegrationTests\FlaUI.Mcp.IntegrationTests.csproj --configuration Release --no-build`

Original contributor credited in the commit.